### PR TITLE
Update monolog for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.2",
     "laravel/framework": "7.0 || ^8.0 || ^9.0 || ^10.0",
-    "monolog/monolog": "2.*"
+    "monolog/monolog": "2.* || 3.*"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Laravel 10 requires Monolog 3.0 minimum to install.